### PR TITLE
Add initialization for Platform class and update state machine

### DIFF
--- a/ka5010-sp/include/Platform.h
+++ b/ka5010-sp/include/Platform.h
@@ -22,6 +22,7 @@ class Platform {
         Platform();
 
         void attachPlatform(int _id, int _n_cups, int _turn_direction, int _max_speed, int _max_acc, int _disable_after_moving);
+        void begin();
 
         //Methods
         void configureDriver();

--- a/ka5010-sp/include/PlatformStateMachine.h
+++ b/ka5010-sp/include/PlatformStateMachine.h
@@ -55,9 +55,6 @@ PlatformConfig config;
 // Platform instance
 Platform platform;
 
-// Delays
-unsigned long int take_platform_delay = 5000; // Delay to take a cup from the platform [ms]
-unsigned long int serve_platform_delay = 8000; // Delay to serve a cup on the platform [ms]
 
 // WiFi Config
 String ssid;

--- a/ka5010-sp/src/Platform.cpp
+++ b/ka5010-sp/src/Platform.cpp
@@ -19,9 +19,28 @@ void Platform::attachPlatform(int _id, int _n_cups, int _turn_direction, int _ma
     max_acc = _max_acc;
     disable_after_moving = _disable_after_moving;
 
-    // Set the limit distance for stable cup detection
-    limitDistance = 10.0; // Example value in cm
-    disable_after_moving = true; // Default value
+    // Default limit distance until configuration is loaded
+    limitDistance = 10.0; // [cm]
+}
+
+void Platform::begin() {
+    // Configure GPIOs
+    pinMode(driver_pul, OUTPUT);
+    pinMode(driver_dir, OUTPUT);
+    pinMode(driver_en, OUTPUT);
+
+    pinMode(trigPin, OUTPUT);
+    pinMode(echoPin, INPUT);
+
+    pinMode(limitSwitchPin, INPUT_PULLUP);
+    attachInterrupt(digitalPinToInterrupt(limitSwitchPin), Platform::stopMotor, RISING);
+
+    // Driver and stepper setup
+    configureDriver();
+    stepper.setMaxSpeed(max_speed);
+    stepper.setAcceleration(max_acc);
+
+    digitalWrite(driver_en, LOW); // Enable driver
 }
 
 
@@ -168,4 +187,8 @@ Platform::RotationStatus Platform::rotateToLimit(){
     }
 
     return ROTATING;
+}
+
+void IRAM_ATTR Platform::stopMotor() {
+    limitReached = true;
 }

--- a/ka5010-sp/src/PlatformStateMachine.cpp
+++ b/ka5010-sp/src/PlatformStateMachine.cpp
@@ -18,6 +18,7 @@
 void setup() {
 
     platform.attachPlatform(config.id, config.n_cups, config.turn_direction, config.max_speed, config.max_acc, config.disable_after_moving);
+    platform.begin();
     
     Serial.begin(9600);
     SERIAL_PORT.begin(9600);
@@ -609,32 +610,32 @@ void loadConfig()
                     Serial.println(platform.disable_after_moving);
                 }
 
-                take_platform_delay = config["take_platform_delay"];
-                if (take_platform_delay != 0)
+                platform.take_platform_delay = config["take_platform_delay"];
+                if (platform.take_platform_delay != 0)
                 {
                     Serial.print("Loaded config for take_platform_delay: ");
-                    Serial.println(take_platform_delay);
+                    Serial.println(platform.take_platform_delay);
                 }
                 else
                 {
                     Serial.println("Could not find take_platform_delay config");
-                    take_platform_delay = 5000; // Valor predeterminado
+                    platform.take_platform_delay = 5000; // Valor predeterminado
                     Serial.print("Using default config for take_platform_delay: ");
-                    Serial.println(take_platform_delay);
+                    Serial.println(platform.take_platform_delay);
                 }
 
-                serve_platform_delay = config["serve_platform_delay"];
-                if (serve_platform_delay != 0)
+                platform.serve_platform_delay = config["serve_platform_delay"];
+                if (platform.serve_platform_delay != 0)
                 {
                     Serial.print("Loaded config for serve_platform_delay: ");
-                    Serial.println(serve_platform_delay);
+                    Serial.println(platform.serve_platform_delay);
                 }
                 else
                 {
                     Serial.println("Could not find serve_platform_delay config");
-                    serve_platform_delay = 8000; // Valor predeterminado
+                    platform.serve_platform_delay = 8000; // Valor predeterminado
                     Serial.print("Using default config for serve_platform_delay: ");
-                    Serial.println(serve_platform_delay);
+                    Serial.println(platform.serve_platform_delay);
                 }
 
                 if (config["bottles"].is<JsonArray>()) {
@@ -672,8 +673,8 @@ void useDefaultConfig()
     platform.max_speed = 1500;               // [rev/min]
     platform.max_acc = 200;                 // [rev/min2]
     platform.disable_after_moving = false;
-    take_platform_delay = 5000;
-    serve_platform_delay = 8000;
+    platform.take_platform_delay = 5000;
+    platform.serve_platform_delay = 8000;
 
 
     Serial.print("ssid ");

--- a/solucion.md
+++ b/solucion.md
@@ -1,0 +1,16 @@
+# Plan para migración a la clase Platform
+
+1. **Revisar el código original**: Analizar `main_tanyaTMC.cpp` para extraer toda la configuración de pines, inicialización de sensores y driver. Ejemplo en las líneas 81‑98 se configuran los pines de motor, sensor y el `attachInterrupt` para el final de carrera.
+2. **Completar la clase `Platform`**: Añadir a `Platform.cpp` un método de inicialización que incluya:
+   - `pinMode` para `driver_pul`, `driver_dir`, `driver_en`, `trigPin`, `echoPin` y `limitSwitchPin`.
+   - `attachInterrupt(digitalPinToInterrupt(limitSwitchPin), stopMotor, RISING)`.
+   - Arranque del driver y parámetros de `AccelStepper`.
+   - Definición de `Platform::stopMotor()` para actualizar la bandera `limitReached`.
+3. **Ajustar `attachPlatform`**: Utilizar este método para almacenar los parámetros de configuración recibidos y llamar a la nueva función de inicialización.
+4. **Actualizar `PlatformStateMachine`**: En `setup()` llamar a `platform.attachPlatform(...)` seguido de `platform.begin()` (la nueva función de inicialización). Asegurarse de que las llamadas a `configureDriver` y a la configuración de velocidad se realizan dentro de `begin()` o inmediatamente después.
+5. **Migrar variables globales**: Todas las variables relacionadas con la plataforma (p. ej. `cups_on_platform`, `limitDistance`, etc.) deben convertirse en miembros de la clase. Revisar que en el `state machine` se accede mediante `platform.miembro` y no con variables globales antiguas.
+6. **Revisar la lógica de lectura del sensor**: El método `updateCupPresence()` ya encapsula la lectura ultrasónica (líneas 90‑109 de `Platform.cpp`). Sustituir en el `loop` las lecturas manuales por llamadas a este método.
+7. **Verificar estados**: La máquina de estados actual para `id=1` se basa en la previa. Confirmar que los cambios en `state`, `cups_on_platform` y el control del motor utilizan las funciones de `Platform` (por ejemplo `moveToNextCup()` y `rotateToLimit()`).
+8. **Probar el código**: Compilar con `platformio` usando la configuración de `platformio.ini` y cargar en el dispositivo. Observar por consola que el sensor muestra valores distintos de `0.0` y que el motor gira en la etapa de inicialización.
+9. **Depurar**: Si el motor no gira, verificar conexiones físicas, dirección de giro (`turn_direction`) y valores de `max_speed` y `max_acc`. Si el sensor sigue mostrando `0.0`, revisar el cableado y el cálculo de la distancia en `readUltrasonicSensor()`.
+10. **Limpiar**: Una vez todo funcione, eliminar el código antiguo (`main_tanyaTMC.*`) o mantenerlo como referencia, y documentar la inicialización y los estados dentro de la clase para futuras ampliaciones.


### PR DESCRIPTION
## Summary
- extend `Platform` class with `begin()` and limit switch interrupt
- adjust `attachPlatform` defaults and implement `stopMotor`
- use new initialization in `PlatformStateMachine` and migrate delay configs into `Platform`

## Testing
- `pio run` *(failed: couldn't download PlatformIO packages)*

------
https://chatgpt.com/codex/tasks/task_e_68757a927078832ea117f36677f8bea0